### PR TITLE
wb6: set DTS root "compatible" property according to actual CPU model…

### DIFF
--- a/board/contactless/mx6ul_wirenboard/mx6ul_wirenboard.c
+++ b/board/contactless/mx6ul_wirenboard/mx6ul_wirenboard.c
@@ -571,7 +571,8 @@ int ft_board_setup(void *blob, bd_t *bd)
 	char * new_compat_end = buffer;
 	size_t new_compat_len = 0;
 
-	for (size_t i=0; ; i++ ) {
+	size_t i;
+	for (i=0; ; i++ ) {
 		nodep = fdt_stringlist_get(blob, 0, "compatible", i, &lenp);
 		if (nodep) {
 			if ((strcmp(nodep, imx6ul_compat_str) != 0) && \

--- a/include/configs/mx6ul_wirenboard.h
+++ b/include/configs/mx6ul_wirenboard.h
@@ -62,6 +62,10 @@
 #define STATUS_LED_STATE	STATUS_LED_ON
 #define STATUS_LED_PERIOD	(CONFIG_SYS_HZ / 2)
 
+/* Additional DTS setup is needed to set "compatible"
+ * property according to CPU type (6UL/6ULL) */
+#define CONFIG_OF_BOARD_SETUP
+
 #ifndef CONFIG_BOOT_USBGADGET
 #define CONFIG_BOOTCOUNT_LIMIT
 #define CONFIG_BOOTCOUNT_ENV


### PR DESCRIPTION
… (6UL or 6ULL)

В линуксе (почему-то) сейчас нет автоопределения типа процессора, он полагается на поле compatible. Меняем его из u-boot, чтобы держать одинаковый DTS и образ на модели с i.mx6UL и i.mx6ULL.