### PR TITLE
Move initial declaration out of for loop.

### DIFF
--- a/board/contactless/mx6ul_wirenboard/mx6ul_wirenboard.c
+++ b/board/contactless/mx6ul_wirenboard/mx6ul_wirenboard.c
@@ -571,7 +571,8 @@ int ft_board_setup(void *blob, bd_t *bd)
 	char * new_compat_end = buffer;
 	size_t new_compat_len = 0;
 
-	for (size_t i=0; ; i++ ) {
+	size_t i;
+	for (i=0; ; i++ ) {
 		nodep = fdt_stringlist_get(blob, 0, "compatible", i, &lenp);
 		if (nodep) {
 			if ((strcmp(nodep, imx6ul_compat_str) != 0) && \


### PR DESCRIPTION
This fixes following error:
error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode